### PR TITLE
[FLOC-4321] A couple __eq__ optimization for PClass

### DIFF
--- a/pyrsistent/_pclass.py
+++ b/pyrsistent/_pclass.py
@@ -137,9 +137,12 @@ class PClass(CheckedType):
     def __eq__(self, other):
         if self is other:
             return True
-        if hash(self) != hash(other):
-            return False
         if isinstance(other, self.__class__):
+            try:
+                if hash(self) != hash(other):
+                    return False
+            except:
+                pass
             for name in self._pclass_fields:
                 if getattr(self, name, _MISSING_VALUE) != getattr(other, name, _MISSING_VALUE):
                     return False

--- a/pyrsistent/_pclass.py
+++ b/pyrsistent/_pclass.py
@@ -135,6 +135,10 @@ class PClass(CheckedType):
         return transform(self, transformations)
 
     def __eq__(self, other):
+        if self is other:
+            return True
+        if hash(self) != hash(other):
+            return False
         if isinstance(other, self.__class__):
             for name in self._pclass_fields:
                 if getattr(self, name, _MISSING_VALUE) != getattr(other, name, _MISSING_VALUE):

--- a/tests/class_test.py
+++ b/tests/class_test.py
@@ -117,6 +117,8 @@ def test_implements_proper_equality_based_on_equality_of_fields():
     p2 = Point(x=3)
     p3 = Point(x=1, y=2)
 
+    assert p1 == p1
+    assert not p1 != p1
     assert p1 == p3
     assert not p1 != p3
     assert p1 != p2

--- a/tests/class_test.py
+++ b/tests/class_test.py
@@ -125,6 +125,64 @@ def test_implements_proper_equality_based_on_equality_of_fields():
     assert not p1 == p2
 
 
+def test_equality_of_unhashable_pclasses():
+    class MyClass(PClass):
+        a = field()
+    o1 = MyClass(a=dict(x=1))
+    o2 = MyClass(a=dict(x=1))
+
+    assert o1 == o2
+    assert not o1 != o2
+
+
+def test_cross_type_equals():
+    class HashCloner(PClass):
+        other = field()
+
+        def __hash__(self):
+            return hash(self.other)
+
+    class HashNegater(PClass):
+        other = field()
+
+        def __hash__(self):
+            return 1 - hash(self.other)
+
+    class TotalCloner(PClass):
+        other = field()
+
+        def __hash__(self):
+            return hash(self.other)
+
+        def __eq__(self, other):
+            return self.other == other
+
+    class HashNegatedEqualCloner(PClass):
+        other = field()
+
+        def __hash__(self):
+            return 1 - hash(self.other)
+
+        def __eq__(self, other):
+            return self.other == other
+
+    p = Point(x=1, y=2)
+    p_like = HashCloner(other=p)
+    p_dislike = HashNegater(other=p)
+    p_exactly_like = TotalCloner(other=p)
+    p_mis_hashed = HashNegatedEqualCloner(other=p)
+
+    assert not p == p_like
+    assert p != p_like
+    assert not p == p_dislike
+    assert p != p_dislike
+
+    assert p == p_exactly_like
+    assert not p != p_exactly_like
+    assert p == p_mis_hashed
+    assert not p != p_mis_hashed
+
+
 def test_is_hashable():
     p1 = Point(x=1, y=2)
     p2 = Point(x=3, y=2)


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4321

We've noticed some slowness is `PClass.__eq__` with large PClasses that are composed mostly of large PClasses that are mostly equal (one is simply the other with .set() executed on a few of the fields, most of which are other PClasses).

It occurred to us that we could just do a simple optimization in `__eq__` to exploit the fact that most of the sub-PClasses are the exact same object.
