### PR TITLE
[FLOC-4329] Store the hash of a PClass when an instance is created.

### DIFF
--- a/pyrsistent/_pclass.py
+++ b/pyrsistent/_pclass.py
@@ -12,7 +12,7 @@ class PClassMeta(type):
     def __new__(mcs, name, bases, dct):
         set_fields(dct, bases, name='_pclass_fields')
         store_invariants(dct, bases, '_pclass_invariants', '__invariant__')
-        dct['__slots__'] = ('_pclass_frozen','_hash',) + tuple(key for key in dct['_pclass_fields'])
+        dct['__slots__'] = ('_pclass_frozen','_pclass_hash',) + tuple(key for key in dct['_pclass_fields'])
 
         # There must only be one __weakref__ entry in the inheritance hierarchy,
         # lets put it on the top level class.
@@ -69,9 +69,9 @@ class PClass(CheckedType):
         check_global_invariants(result, cls._pclass_invariants)
 
         try:
-            result._hash = hash(tuple((key, getattr(result, key, _MISSING_VALUE)) for key in result._pclass_fields))
+            result._pclass_hash = hash(tuple((key, getattr(result, key, _MISSING_VALUE)) for key in result._pclass_fields))
         except:
-           result._hash = None
+           result._pclass_hash = None
         result._pclass_frozen = True
         return result
 
@@ -152,10 +152,9 @@ class PClass(CheckedType):
         return not self == other
 
     def __hash__(self):
-        # May want to optimize this by caching the hash somehow
-        if not self._hash:
+        if self._pclass_hash is None:
             return hash(tuple((key, getattr(self, key, _MISSING_VALUE)) for key in self._pclass_fields))
-        return self._hash
+        return self._pclass_hash
 
     def __setattr__(self, key, value):
         if getattr(self, '_pclass_frozen', False):

--- a/pyrsistent/_pclass.py
+++ b/pyrsistent/_pclass.py
@@ -12,7 +12,7 @@ class PClassMeta(type):
     def __new__(mcs, name, bases, dct):
         set_fields(dct, bases, name='_pclass_fields')
         store_invariants(dct, bases, '_pclass_invariants', '__invariant__')
-        dct['__slots__'] = ('_pclass_frozen',) + tuple(key for key in dct['_pclass_fields'])
+        dct['__slots__'] = ('_pclass_frozen','_hash',) + tuple(key for key in dct['_pclass_fields'])
 
         # There must only be one __weakref__ entry in the inheritance hierarchy,
         # lets put it on the top level class.
@@ -68,6 +68,10 @@ class PClass(CheckedType):
 
         check_global_invariants(result, cls._pclass_invariants)
 
+        try:
+            result._hash = hash(tuple((key, getattr(result, key, _MISSING_VALUE)) for key in result._pclass_fields))
+        except:
+           result._hash = None
         result._pclass_frozen = True
         return result
 
@@ -149,7 +153,9 @@ class PClass(CheckedType):
 
     def __hash__(self):
         # May want to optimize this by caching the hash somehow
-        return hash(tuple((key, getattr(self, key, _MISSING_VALUE)) for key in self._pclass_fields))
+        if not self._hash:
+            return hash(tuple((key, getattr(self, key, _MISSING_VALUE)) for key in self._pclass_fields))
+        return self._hash
 
     def __setattr__(self, key, value):
         if getattr(self, '_pclass_frozen', False):

--- a/tests/class_test.py
+++ b/tests/class_test.py
@@ -138,6 +138,18 @@ def test_is_hashable():
     assert Point(x=10) not in d
 
 
+def test_is_not_hashable_if_fields_are_not():
+    class MyClass(PClass):
+        a = field()
+    b = MyClass(a=dict(x=1))
+    try:
+        hash(b)
+        assert False
+    except TypeError as e:
+        assert "unhashable" in str(e)
+        assert "dict" in str(e)
+
+
 def test_supports_nested_transformation():
     l1 = Line(p1=Point(x=2, y=1), p2=Point(x=20, y=10))
 


### PR DESCRIPTION
Attempt to store the hash of a PClass instance. If calculating the
hash fails for any reason, fall back to calculating it every time
`__hash__` is called.
