### PR TITLE
[FLOC-4353] Pmap hash cache floc 4353

### DIFF
--- a/pyrsistent/_pmap.py
+++ b/pyrsistent/_pmap.py
@@ -40,7 +40,7 @@ class PMap(object):
     >>> m3['c']
     3
     """
-    __slots__ = ('_size', '_buckets', '__weakref__')
+    __slots__ = ('_size', '_buckets', '__weakref__', '_cached_hash')
 
     def __new__(cls, size, buckets):
         self = super(PMap, cls).__new__(cls)
@@ -140,7 +140,9 @@ class PMap(object):
 
     def __hash__(self):
         # This hashing algorithm is probably not the speediest
-        return hash(frozenset(self.iteritems()))
+        if not hasattr(self, '_cached_hash'):
+            self._cached_hash = hash(frozenset(self.iteritems()))
+        return self._cached_hash
 
     def set(self, key, val):
         """

--- a/pyrsistent/_pmap.py
+++ b/pyrsistent/_pmap.py
@@ -40,7 +40,7 @@ class PMap(object):
     >>> m3['c']
     3
     """
-    __slots__ = ('_size', '_buckets', '__weakref__', '_cached_hash')
+    __slots__ = ('_size', '_buckets', '__weakref__', '_pmap_hash')
 
     def __new__(cls, size, buckets):
         self = super(PMap, cls).__new__(cls)
@@ -139,10 +139,9 @@ class PMap(object):
         return self.__repr__()
 
     def __hash__(self):
-        # This hashing algorithm is probably not the speediest
-        if not hasattr(self, '_cached_hash'):
-            self._cached_hash = hash(frozenset(self.iteritems()))
-        return self._cached_hash
+        if not hasattr(self, '_pmap_hash'):
+            self._pmap_hash = hash(frozenset(self.iteritems()))
+        return self._pmap_hash
 
     def set(self, key, val):
         """

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -138,6 +138,23 @@ def test_same_hash_when_content_the_same_but_underlying_vector_size_differs():
     assert hash(x) == hash(y)
 
 
+class YouOnlyHashOnce(object):
+
+    hashed = False
+
+    def __hash__(self):
+        if self.hashed:
+            raise ValueError("You already hashed me!")
+        self.hashed = True
+        return 4 # Proven random
+
+
+def test_map_only_hashes_element_once():
+    x = pmap(dict(el=YouOnlyHashOnce()))
+    hash(x)
+    hash(x)
+
+
 def test_update_with_multiple_arguments():
     # If same value is present in multiple sources, the rightmost is used.
     x = m(a=1, b=2, c=3)    

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -138,20 +138,21 @@ def test_same_hash_when_content_the_same_but_underlying_vector_size_differs():
     assert hash(x) == hash(y)
 
 
-class YouOnlyHashOnce(object):
+class HashabilityControlled(object):
 
-    hashed = False
+    hashable = True
 
     def __hash__(self):
-        if self.hashed:
-            raise ValueError("You already hashed me!")
-        self.hashed = True
-        return 4 # Proven random
+        if self.hashable:
+            return 4 # Proven random
+        raise ValueError("I am not currently hashable.")
 
 
-def test_map_only_hashes_element_once():
-    x = pmap(dict(el=YouOnlyHashOnce()))
+def test_map_does_not_hash_values_on_second_hash_invocation():
+    hashable = HashabilityControlled()
+    x = pmap(dict(el=hashable))
     hash(x)
+    hashable.hashable = False
     hash(x)
 
 


### PR DESCRIPTION
From profiling today we realized that we get significant additional speedups by also caching the hash of PMaps.

Moshe already had a PR out to pyrsistent to add this, so I grabbed that branch and fixed up the pypy test.
