### PR TITLE
[FLOC-4394] Make PClass.set more likely to return the same object.

### DIFF
--- a/pyrsistent/_pclass.py
+++ b/pyrsistent/_pclass.py
@@ -223,23 +223,28 @@ class _PClassEvolver(object):
         update = False
 
         current_value = self._pclass_evolver_data.get(key, _MISSING_VALUE)
+
         try:
-            if hash(current_value) == hash(value) and current_value == value:
-                # Assume that if the value is hashable then it is immutable. If
-                # the value is the same for an immutable object, then we do not
-                # need to update.
-                update = False
-            else:
-                # Otherwise if there is a hash mismatch or the values are not
-                # the same the key needs to be updated.
-                update = True
-        except TypeError:
-            # Assume that the type error indicates that the value is mutable.
-            # In this case, the only time we do not need to update is if
+            current_value_hash = hash(current_value)
+            value_hash = hash(value)
+        except:
+            # Assume that the error indicates that the value is mutable.  In
+            # this case, the only time we do not need to update is if
             # current_value is the same object as value.
             if current_value is value:
                 update = False
             else:
+                update = True
+        else:
+            # Assume that the lack of an error when we hashed the objects
+            # indicates that they both are immutable.
+            if current_value_hash == value_hash and current_value == value:
+                # If the value is the same for an immutable object, then we do
+                # not need to update.
+                update = False
+            else:
+                # Otherwise if there is a hash mismatch or the values are not
+                # the same the key needs to be updated.
                 update = True
 
         if update:

--- a/pyrsistent/_pclass.py
+++ b/pyrsistent/_pclass.py
@@ -220,37 +220,26 @@ class _PClassEvolver(object):
         return self._pclass_evolver_data[item]
 
     def set(self, key, value):
-        update = False
-
         current_value = self._pclass_evolver_data.get(key, _MISSING_VALUE)
 
         try:
-            current_value_hash = hash(current_value)
-            value_hash = hash(value)
+            hash(current_value)
+            hash(value)
         except:
-            # Assume that the error indicates that the value is mutable.  In
-            # this case, the only time we do not need to update is if
-            # current_value is the same object as value.
+            # Assume that the error indicates that the value is mutable.  As an
+            # optimization, we can return an unmodified self if both objects
+            # are the same.
             if current_value is value:
-                update = False
-            else:
-                update = True
+                return self
         else:
             # Assume that the lack of an error when we hashed the objects
-            # indicates that they both are immutable.
-            if current_value_hash == value_hash and current_value == value:
-                # If the value is the same for an immutable object, then we do
-                # not need to update.
-                update = False
-            else:
-                # Otherwise if there is a hash mismatch or the values are not
-                # the same the key needs to be updated.
-                update = True
+            # indicates that they both are immutable.  As an optimization, we
+            # can return an unmodified self if both objects are equal.
+            if current_value == value:
+                return self
 
-        if update:
-            self._pclass_evolver_data[key] = value
-            self._pclass_evolver_data_is_dirty = True
-
+        self._pclass_evolver_data[key] = value
+        self._pclass_evolver_data_is_dirty = True
         return self
 
     def __setitem__(self, key, value):

--- a/pyrsistent/_pclass.py
+++ b/pyrsistent/_pclass.py
@@ -98,7 +98,7 @@ class PClass(CheckedType):
             kwargs[args[0]] = args[1]
 
         e = self.evolver()
-        for key, value in kwargs.iteritems():
+        for key, value in six.iteritems(kwargs):
             e.set(key, value)
         return e.persistent()
 

--- a/tests/class_test.py
+++ b/tests/class_test.py
@@ -298,8 +298,10 @@ def test_set_mutable_types_only_returns_original_if_exact_object():
 
     d1 = dict(x=1)
     c1 = MyClass(a=d1)
-    assert c1.set(a=d1) is c1
-    assert c1.set(a=dict(x=1)) is not c1
+    c1_clone = c1.set(a=d1)
+    c1_equivalent = c1.set(a=dict(x=1))
+    assert c1_clone is c1
+    assert c1_equivalent is not c1
 
 
 def test_evolver_without_evolution_returns_original_instance():

--- a/tests/class_test.py
+++ b/tests/class_test.py
@@ -279,6 +279,29 @@ def test_cannot_remove_non_existing_member():
         p1.remove('y')
 
 
+def test_set_equal_basic_types_returns_original_instance():
+    p1 = Point(x=1)
+
+    assert p1.set('x', 1) is p1
+    assert p1.set(x=1) is p1
+
+
+def test_set_equal_pyrsistent_types_returns_original_instance():
+    l1 = Line(p1=Point(x=2, y=1), p2=Point(x=20, y=10))
+
+    assert l1.set(p1=Point(x=2, y=1)) is l1
+
+
+def test_set_mutable_types_only_returns_original_if_exact_object():
+    class MyClass(PClass):
+        a = field()
+
+    d1 = dict(x=1)
+    c1 = MyClass(a=d1)
+    assert c1.set(a=d1) is c1
+    assert c1.set(a=dict(x=1)) is not c1
+
+
 def test_evolver_without_evolution_returns_original_instance():
     p1 = Point(x=1)
     e = p1.evolver()


### PR DESCRIPTION
Our PClass.**eq** `is` optimization is more likely to hit if we don't create lots of equivalent PClasses.

This PR assists in reducing the number of PClasses created by returning self when PClass.set('x', current_value_of_field_x) is called.
