### PR TITLE
[FLOC-4406] Add fast-path optimizations to PMap.__eq__

### DIFF
--- a/pyrsistent/_pmap.py
+++ b/pyrsistent/_pmap.py
@@ -136,8 +136,9 @@ class PMap(object):
         else:
             if self_hash != other_hash:
                 return False
-        return Mapping.__eq__(self, other)
+        return self._mapping_eq(other)
 
+    _mapping_eq = Mapping.__eq__
     __ne__ = Mapping.__ne__
 
     def __lt__(self, other):

--- a/pyrsistent/_pmap.py
+++ b/pyrsistent/_pmap.py
@@ -131,7 +131,7 @@ class PMap(object):
         try:
             self_hash = hash(self)
             other_hash = hash(other)
-        except:
+        except TypeError:
             pass
         else:
             if self_hash != other_hash:

--- a/pyrsistent/_pmap.py
+++ b/pyrsistent/_pmap.py
@@ -125,12 +125,11 @@ class PMap(object):
     def __repr__(self):
         return 'pmap({0})'.format(str(dict(self)))
 
-    #def __eq__(self, other):
-    #    if self is other:
-    #        return True
-    #    return Mapping.__eq__(self, other)
+    def __eq__(self, other):
+        if self is other:
+            return True
+        return Mapping.__eq__(self, other)
 
-    __eq__ = Mapping.__eq__
     __ne__ = Mapping.__ne__
 
     def __lt__(self, other):

--- a/pyrsistent/_pmap.py
+++ b/pyrsistent/_pmap.py
@@ -128,6 +128,14 @@ class PMap(object):
     def __eq__(self, other):
         if self is other:
             return True
+        try:
+            self_hash = hash(self)
+            other_hash = hash(other)
+        except:
+            pass
+        else:
+            if self_hash != other_hash:
+                return False
         return Mapping.__eq__(self, other)
 
     __ne__ = Mapping.__ne__

--- a/pyrsistent/_pmap.py
+++ b/pyrsistent/_pmap.py
@@ -125,6 +125,11 @@ class PMap(object):
     def __repr__(self):
         return 'pmap({0})'.format(str(dict(self)))
 
+    #def __eq__(self, other):
+    #    if self is other:
+    #        return True
+    #    return Mapping.__eq__(self, other)
+
     __eq__ = Mapping.__eq__
     __ne__ = Mapping.__ne__
 

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -421,16 +421,36 @@ def test_supports_weakref():
     weakref.ref(m(a=1))
 
 
-class TerriblePatchedPMap(PMap):
+class NonIterablePMap(PMap):
+    def __iter__(self):
+        assert False
+
+    def itervalues(self):
+        assert False
+
+    def values(self):
+        assert False
+
+    def iterkeys(self):
+        assert False
+
+    def keys(self):
+        assert False
+
+    def iteritems(self):
+        assert False
+
     def items(self):
         assert False
 
 
 def test_identity_equal_quick():
-    # It might be slow to recursively call __eq__ on all keys and values.
-    # Instead, for maps that are the same object, __eq__ should have a fast
-    # path that does not call __eq__.
-    m1 = TerriblePatchedPMap(0, [])
+    # It might be slow (O(n)) to iterate over all items in a PMap during
+    # comparison. If the maps happen to be the exact same object, there should
+    # be a quick path that does not require iterating over the PMap.
+
+    # Subclass used because PMaps use slots making them un-patchable.
+    m1 = NonIterablePMap(0, [])
     m2 = m1
     assert m1 == m2
 

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -450,6 +450,10 @@ def test_identity_equal_quick():
     # be a quick path that does not require iterating over the PMap.
 
     # Subclass used because PMaps use slots making them un-patchable.
+
+    # Constructing a PMap directly requires passing in the number of elements
+    # and the buckets the PMap uses to store its values. For simplicity, just
+    # use an empty PMap.
     m1 = NonIterablePMap(0, [])
     m2 = m1
     assert m1 == m2

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -470,7 +470,8 @@ def test_differing_hash_quick_nonequal():
     # It might be slow to recursively call __eq__ on all keys and values.
     # Instead, for maps that are composed of hashable (presumably immutable)
     # objects with different hashes, __eq__ should have a fast path that does
-    # not call __eq__.
+    # not call __eq__ on the objects in the PMap, instead relying on the hash,
+    # which is hopefully faster to compute, and possibly already cached.
     im1 = NonEquatableImmutableHash(1)
     im2 = NonEquatableImmutableHash(2)
     m1 = pmap({im1: im1})


### PR DESCRIPTION
This adds 2 fast-path optimizations to PMap.**eq**

1 for two objects that are actually the same object (Turns an O(n) comparison to a O(1)), and one for two objects that hash to different values (Given that we cache the hash, this also is likely to be O(1) in many circumstances).
