### PR TITLE
[FLOC-4427] Return the same object more often.

### DIFF
--- a/pyrsistent/_pclass.py
+++ b/pyrsistent/_pclass.py
@@ -1,7 +1,7 @@
 import six
 from pyrsistent._checked_types import (InvariantException, CheckedType, _restore_pickle, store_invariants)
 from pyrsistent._field_common import (set_fields, check_type, PFIELD_NO_INITIAL, serialize, check_global_invariants)
-from pyrsistent._transformations import transform
+from pyrsistent._transformations import transform, immutably_equivalent
 
 
 def _is_pclass(bases):
@@ -222,21 +222,8 @@ class _PClassEvolver(object):
     def set(self, key, value):
         current_value = self._pclass_evolver_data.get(key, _MISSING_VALUE)
 
-        try:
-            hash(current_value)
-            hash(value)
-        except:
-            # Assume that the error indicates that the value is mutable.  As an
-            # optimization, we can return an unmodified self if both objects
-            # are the same.
-            if current_value is value:
-                return self
-        else:
-            # Assume that the lack of an error when we hashed the objects
-            # indicates that they both are immutable.  As an optimization, we
-            # can return an unmodified self if both objects are equal.
-            if current_value == value:
-                return self
+        if immutably_equivalent(current_value, value):
+            return True
 
         self._pclass_evolver_data[key] = value
         self._pclass_evolver_data_is_dirty = True

--- a/pyrsistent/_pmap.py
+++ b/pyrsistent/_pmap.py
@@ -2,7 +2,7 @@ from collections import Mapping, Hashable
 from itertools import chain
 import six
 from pyrsistent._pvector import pvector
-from pyrsistent._transformations import transform
+from pyrsistent._transformations import transform, immutably_equivalent
 
 
 class PMap(object):
@@ -294,7 +294,7 @@ class PMap(object):
             if bucket:
                 for k, v in bucket:
                     if k == key:
-                        if v is not val:
+                        if not immutably_equivalent(v,  val):
                             new_bucket = [(k2, v2) if k2 != k else (k2, val) for k2, v2 in bucket]
                             self._buckets_evolver[index] = new_bucket
 

--- a/pyrsistent/_transformations.py
+++ b/pyrsistent/_transformations.py
@@ -50,7 +50,6 @@ def immutably_equivalent(a, b):
     """
     if a is b:
         return True
-    return False
     try:
         hash(a)
         hash(b)

--- a/pyrsistent/_transformations.py
+++ b/pyrsistent/_transformations.py
@@ -37,6 +37,29 @@ def _chunks(l, n):
         yield l[i:i + n]
 
 
+def immutably_equivalent(a, b):
+    """
+    Returns whether the arguments are immutably equivalent. This means two
+    different things:
+
+    - If both a and b are hashable, then they both represent immutable values.
+      In this case, returning if a == b should reflect that the objects are
+      equal, and they will always be equal.
+    - If either a or b are not hashable, then they will only be equal in the
+      immutable sense if they refer to the exact same object.
+    """
+    if a is b:
+        return True
+    return False
+    try:
+        hash(a)
+        hash(b)
+    except TypeError:
+        return False
+    else:
+        return a == b
+
+
 def transform(structure, transformations):
     r = structure
     for path, command in _chunks(transformations, 2):
@@ -86,6 +109,6 @@ def _update_structure(structure, kvs, path, command):
             discard(e, k)
         else:
             result = _do_to_path(v, path, command)
-            if result is not v:
+            if not immutably_equivalent(result, v):
                 e[k] = result
     return e.persistent()

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -422,9 +422,9 @@ def test_supports_weakref():
 
 
 def test_set_equal_same_object():
-    make_subobj = lambda: freeze({'foo': [1, 2, 3]})
+    make_subobj = lambda: m(foo='bar')
     m1 = m(foo=make_subobj())
-    assert m1.set('foo', make_subobj()) is m
+    assert m1.set('foo', make_subobj()) is m1
 
 
 class NonIterablePMap(PMap):

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -421,6 +421,12 @@ def test_supports_weakref():
     weakref.ref(m(a=1))
 
 
+def test_set_equal_same_object():
+    make_subobj = lambda: freeze({'foo': [1, 2, 3]})
+    m1 = m(foo=make_subobj())
+    assert m1.set('foo', make_subobj()) is m
+
+
 class NonIterablePMap(PMap):
     def __iter__(self):
         assert False

--- a/tests/transform_test.py
+++ b/tests/transform_test.py
@@ -80,3 +80,9 @@ def test_multiple_transformations():
 def test_no_transformation_returns_the_same_structure():
     v = freeze([{'foo': 1}, {'bar': 2}])
     assert v.transform([ny, ny], lambda x: x) is v
+
+
+def test_replace_subobject_returns_the_same_structure():
+    make_subobj = lambda *_: freeze({'foo': [1, 2, 3]})
+    m = freeze({'foo': make_subobj()})
+    assert m.transform(['foo'], make_subobj) is m


### PR DESCRIPTION
With larger and larger pyrsistent objects it becomes even more important to get the exact same object back from transformations and calls to `set` if they could be no-ops so that the `__eq__` optimization is hit more frequently.

I saw increased CPU time in pmap.**eq** despite the `hash` optimization in Pmap.**eq** which suggested to me that objects that had the same hash, but were not the exact same object were being compared. This seems to have made the problem decrease in severity.
